### PR TITLE
Fix CONTRIBUTING.md link in feature request issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -5,7 +5,7 @@ body:
 - type: checkboxes
   attributes:
     label: Have you read a contributing guide?
-    description: Please read [CONTRIBUTING.md](https://github.com/anyproto/.github/blob/main/docs/SECURITY.md) before proceeding. Check if there are existing [feature requests](https://community.anytype.io/c/feature-requests/l/latest?board=default) and upvote them instead. Follow [this article](https://doc.anytype.io/d/community/community-forum) if you don't know how to join the community.
+    description: Please read [CONTRIBUTING.md](https://github.com/anyproto/.github/blob/main/docs/CONTRIBUTING.md) before proceeding. Check if there are existing [feature requests](https://community.anytype.io/c/feature-requests/l/latest?board=default) and upvote them instead. Follow [this article](https://doc.anytype.io/d/community/community-forum) if you don't know how to join the community.
     options:
     - label: I have read CONTRIBUTING.md
       required: true


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

This PR fixes a bug in the feature request issue template where the text with CONTRIBUTING.md links to SECURITY.md

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [x] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
